### PR TITLE
Add agentic compose console and 2025 best-practice guidance

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "media-server-webui",
       "version": "1.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.62.7",
         "axios": "^1.6.0",
         "dockerode": "^3.3.1",
         "express": "^4.18.2",
@@ -1037,6 +1038,32 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.11.tgz",
+      "integrity": "sha512-f9z/nXhCgWDF4lHqgIE30jxLe4sYv15QodfdPDKYAk7nAEjNcndy4dHz3ezhdUaR23BpWa4I2EH4/DZ0//Uf8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.11.tgz",
+      "integrity": "sha512-3uyzz01D1fkTLXuxF3JfoJoHQMU2fxsfJwE+6N5hHy0dVNoZOvwKP8Z2k7k1KDeD54N20apcJnG75TBAStIrBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.11"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/webui/package.json
+++ b/webui/package.json
@@ -9,6 +9,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.62.7",
     "express": "^4.18.2",
     "dockerode": "^3.3.1",
     "react": "^18.2.0",

--- a/webui/server.js
+++ b/webui/server.js
@@ -1,29 +1,128 @@
 import express from 'express';
 import { exec } from 'child_process';
-import path from 'path';
 import { fileURLToPath } from 'url';
+import { promisify } from 'util';
+import path from 'path';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const app = express();
 const PORT = process.env.PORT || 3000;
 const STACK_DIR = process.env.STACK_DIR || path.join(__dirname, '..');
+const COMPOSE_CMD = process.env.COMPOSE_CMD || 'docker compose';
+const execAsync = promisify(exec);
 
-app.use(express.json());
+const ALLOWED_ACTIONS = {
+  status: `${COMPOSE_CMD} ps --format json`,
+  start: `${COMPOSE_CMD} up -d`,
+  stop: `${COMPOSE_CMD} down`,
+  restart: `${COMPOSE_CMD} down && ${COMPOSE_CMD} up -d`,
+};
+
+const BEST_PRACTICES = [
+  {
+    title: 'Encrypted ingress everywhere',
+    detail: 'Ensure Traefik issues TLS certs for every service and enforce HTTPS → HTTP redirects.',
+  },
+  {
+    title: 'Per-service health probes',
+    detail:
+      'Use 30s interval HTTP checks for Jellyfin, Sonarr, Radarr, Prowlarr, and qBittorrent to keep Watchtower honest.',
+  },
+  {
+    title: 'Immutable builds + pinned tags',
+    detail: 'Pin critical images (Jellyfin, qBittorrent, *arr apps) to digest tags before enabling auto-updates.',
+  },
+  {
+    title: 'Network segmentation',
+    detail: 'Run public ingress on a distinct Traefik network and isolate download clients on a private bridge.',
+  },
+  {
+    title: 'Secrets over env',
+    detail: 'Prefer Docker secrets for API tokens and passwords; reserve env vars for non-sensitive toggles.',
+  },
+];
+
+app.use(express.json({ limit: '1mb' }));
 app.use(express.static(path.join(__dirname, 'dist')));
 
-function run(cmd, res) {
-  exec(cmd, { cwd: STACK_DIR }, (err, stdout, stderr) => {
-    if (err) {
-      res.status(500).send(stderr);
-    } else {
-      res.type('text/plain').send(stdout);
-    }
+async function runCommand(command) {
+  const { stdout, stderr } = await execAsync(command, {
+    cwd: STACK_DIR,
+    timeout: 60_000,
+    maxBuffer: 10 * 1024 * 1024,
   });
+
+  if (stderr) {
+    return { output: stdout || stderr, stderr };
+  }
+
+  return { output: stdout };
 }
 
-app.get('/api/status', (req, res) => run('docker compose ps', res));
-app.post('/api/start', (req, res) => run('docker compose up -d', res));
-app.post('/api/stop', (req, res) => run('docker compose down', res));
+function parseComposeJson(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed;
+    if (parsed.services) return parsed.services;
+    return null;
+  } catch (err) {
+    return null;
+  }
+}
+
+app.get('/api/compose/status', async (req, res) => {
+  const command = ALLOWED_ACTIONS.status;
+  try {
+    const { output } = await runCommand(command);
+    const parsed = parseComposeJson(output);
+    res.json({ raw: output, summary: parsed });
+  } catch (err) {
+    res.status(500).json({ error: err.message, raw: err.stderr || err.stdout || '' });
+  }
+});
+
+app.post('/api/compose/:action', async (req, res) => {
+  const action = req.params.action;
+  const command = ALLOWED_ACTIONS[action];
+
+  if (!command) {
+    return res.status(400).json({ error: 'Unsupported action' });
+  }
+
+  try {
+    const { output } = await runCommand(command);
+    res.json({ message: `${action} executed`, raw: output });
+  } catch (err) {
+    res.status(500).json({ error: err.message, raw: err.stderr || err.stdout || '' });
+  }
+});
+
+app.post('/api/agent/batch', async (req, res) => {
+  const actions = Array.isArray(req.body?.actions) ? req.body.actions : [];
+  const logs = [];
+
+  for (const action of actions) {
+    const command = ALLOWED_ACTIONS[action];
+    if (!command) {
+      logs.push({ action, status: 'skipped', output: 'Unsupported action' });
+      continue;
+    }
+
+    try {
+      const { output } = await runCommand(command);
+      logs.push({ action, status: 'ok', output });
+    } catch (err) {
+      logs.push({ action, status: 'error', output: err.stderr || err.stdout || err.message });
+      break;
+    }
+  }
+
+  res.json({ completed: logs });
+});
+
+app.get('/api/best-practices', (req, res) => {
+  res.json({ generatedAt: new Date().toISOString(), items: BEST_PRACTICES });
+});
 
 app.listen(PORT, () => {
   console.log(`Web UI listening on port ${PORT}`);

--- a/webui/src/App.jsx
+++ b/webui/src/App.jsx
@@ -1,27 +1,261 @@
-import React, { useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import axios from 'axios';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-export default function App() {
-  const [output, setOutput] = useState('');
+const composeClient = axios.create({ baseURL: '/api' });
 
-  const run = async (method) => {
-    try {
-      const res = await axios({ url: `/api/${method}`, method: method === 'status' ? 'get' : 'post' });
-      setOutput(res.data);
-    } catch (err) {
-      setOutput(err.response ? err.response.data : 'Error');
-    }
-  };
+const agentPlaybooks = [
+  {
+    name: 'Start + verify',
+    actions: ['start', 'status'],
+    description: 'Boot the stack and confirm every service reports healthy via compose.',
+  },
+  {
+    name: 'Graceful restart',
+    actions: ['stop', 'start', 'status'],
+    description: 'Tear down cleanly, then bring the stack back up with a fresh status snapshot.',
+  },
+  {
+    name: 'Status only',
+    actions: ['status'],
+    description: 'Lightweight 2025-ready audit to see what Compose reports right now.',
+  },
+];
+
+function useComposeStatus() {
+  return useQuery({
+    queryKey: ['compose-status'],
+    refetchInterval: 15_000,
+    queryFn: async () => {
+      const res = await composeClient.get('/compose/status');
+      return res.data;
+    },
+  });
+}
+
+function StatusTable({ summary }) {
+  if (!summary || summary.length === 0) return <p className="muted">Compose did not return structured service data.</p>;
 
   return (
-    <div className="container">
-      <h1>Media Server Stack</h1>
-      <div className="buttons">
-        <button onClick={() => run('status')}>Status</button>
-        <button onClick={() => run('start')}>Start</button>
-        <button onClick={() => run('stop')}>Stop</button>
+    <div className="table" role="table">
+      <div className="table-row table-head" role="row">
+        <div role="columnheader">Service</div>
+        <div role="columnheader">State</div>
+        <div role="columnheader">Health</div>
       </div>
-      <pre>{output}</pre>
+      {summary.map((service) => (
+        <div key={service.Service || service.Name} className="table-row" role="row">
+          <div role="cell">{service.Service || service.Name}</div>
+          <div role="cell" className={service.State?.includes('running') ? 'pill success' : 'pill warning'}>
+            {service.State || 'unknown'}
+          </div>
+          <div role="cell" className={service.Health ? 'pill success' : 'pill muted'}>
+            {service.Health?.Status || service.Health || 'n/a'}
+          </div>
+        </div>
+      ))}
     </div>
+  );
+}
+
+function BestPractices() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['best-practices'],
+    queryFn: async () => {
+      const res = await composeClient.get('/best-practices');
+      return res.data;
+    },
+  });
+
+  if (isLoading) return <p className="muted">Loading 11/2025 best practices…</p>;
+  if (isError) return <p className="error">Could not load best practices.</p>;
+
+  return (
+    <div className="grid">
+      {data.items.map((item) => (
+        <article key={item.title} className="card">
+          <h3>{item.title}</h3>
+          <p>{item.detail}</p>
+        </article>
+      ))}
+    </div>
+  );
+}
+
+function ComposeActions() {
+  const queryClient = useQueryClient();
+  const [log, setLog] = useState('');
+
+  const mutation = useMutation({
+    mutationFn: async (action) => {
+      const res = await composeClient.post(`/compose/${action}`);
+      return { action, data: res.data };
+    },
+    onSuccess: async ({ action, data }) => {
+      setLog((prev) => `${new Date().toLocaleTimeString()} • ${action}: ${data.raw || data.message}\n${prev}`);
+      await queryClient.invalidateQueries({ queryKey: ['compose-status'] });
+    },
+    onError: (error, action) => {
+      const description = error.response?.data?.error || error.message;
+      setLog((prev) => `${new Date().toLocaleTimeString()} • ${action} failed: ${description}\n${prev}`);
+    },
+  });
+
+  const runAction = useCallback((action) => mutation.mutate(action), [mutation]);
+
+  return (
+    <section className="card">
+      <header className="card-header">
+        <div>
+          <p className="eyebrow">Compose control</p>
+          <h2>Agentic controls</h2>
+          <p className="muted">Start, stop, or restart the stack with guardrails to prevent ad-hoc shelling.</p>
+        </div>
+        <div className="button-row">
+          <button disabled={mutation.isPending} onClick={() => runAction('status')} className="ghost">
+            Status
+          </button>
+          <button disabled={mutation.isPending} onClick={() => runAction('start')}>
+            Start
+          </button>
+          <button disabled={mutation.isPending} onClick={() => runAction('stop')} className="danger">
+            Stop
+          </button>
+          <button disabled={mutation.isPending} onClick={() => runAction('restart')} className="secondary">
+            Restart
+          </button>
+        </div>
+      </header>
+      <pre className="log-window">{log || 'Actions and compose output will appear here.'}</pre>
+    </section>
+  );
+}
+
+function AgentPlaybook() {
+  const [selected, setSelected] = useState(agentPlaybooks[0]);
+  const [history, setHistory] = useState([]);
+
+  const mutation = useMutation({
+    mutationFn: async (payload) => {
+      const res = await composeClient.post('/agent/batch', payload);
+      return res.data.completed;
+    },
+    onSuccess: (completed) => {
+      setHistory(completed);
+    },
+  });
+
+  const runPlaybook = useCallback(() => {
+    mutation.mutate({ actions: selected.actions });
+  }, [mutation, selected]);
+
+  return (
+    <section className="card">
+      <header className="card-header">
+        <div>
+          <p className="eyebrow">Automation</p>
+          <h2>Agentic playbooks</h2>
+          <p className="muted">Pre-baked sequences for safe, repeatable operations that align with 2025 hardening guidance.</p>
+        </div>
+        <div className="playbook-select">
+          <label htmlFor="playbook">Playbook</label>
+          <select
+            id="playbook"
+            value={selected.name}
+            onChange={(e) => setSelected(agentPlaybooks.find((p) => p.name === e.target.value))}
+          >
+            {agentPlaybooks.map((playbook) => (
+              <option key={playbook.name} value={playbook.name}>
+                {playbook.name}
+              </option>
+            ))}
+          </select>
+          <button onClick={runPlaybook} disabled={mutation.isPending} className="secondary">
+            Run
+          </button>
+        </div>
+      </header>
+      <p className="muted">{selected.description}</p>
+      <div className="grid">
+        {history.length === 0 && <p className="muted">No agent runs yet. Pick a playbook to see detailed output.</p>}
+        {history.map((entry) => (
+          <article key={`${entry.action}-${entry.status}`} className="card inset">
+            <header className="chip-row">
+              <span className="chip">{entry.action}</span>
+              <span className={`chip ${entry.status === 'ok' ? 'success' : entry.status === 'error' ? 'danger' : 'muted'}`}>
+                {entry.status}
+              </span>
+            </header>
+            <pre className="log-window small">{entry.output || 'No output reported.'}</pre>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function App() {
+  const statusQuery = useComposeStatus();
+
+  const lastUpdated = useMemo(() => {
+    if (!statusQuery.data) return null;
+    return new Date().toLocaleTimeString();
+  }, [statusQuery.data]);
+
+  return (
+    <main className="page">
+      <header className="hero">
+        <div>
+          <p className="eyebrow">Media Server Stack · November 2025 readiness</p>
+          <h1>Operator console</h1>
+          <p className="muted">
+            Modern controls for Compose with 2025-era best practices, agentic playbooks, and guardrails to avoid brittle scripts.
+          </p>
+        </div>
+        <div className="status-card">
+          <p className="eyebrow">Status refresh</p>
+          <p className="muted">{lastUpdated ? `Auto-refreshed at ${lastUpdated}` : 'Waiting for first pull…'}</p>
+        </div>
+      </header>
+
+      <section className="card">
+        <header className="card-header">
+          <div>
+            <p className="eyebrow">Stack visibility</p>
+            <h2>Compose services</h2>
+          </div>
+          <button onClick={() => statusQuery.refetch()} className="ghost" disabled={statusQuery.isFetching}>
+            Refresh
+          </button>
+        </header>
+        {statusQuery.isError && <p className="error">Could not fetch compose status.</p>}
+        {statusQuery.isLoading && <p className="muted">Loading compose status…</p>}
+        {statusQuery.data && (
+          <>
+            <StatusTable summary={statusQuery.data.summary} />
+            <details className="raw-output">
+              <summary>Raw compose output</summary>
+              <pre className="log-window small">{statusQuery.data.raw}</pre>
+            </details>
+          </>
+        )}
+      </section>
+
+      <div className="layout">
+        <ComposeActions />
+        <AgentPlaybook />
+      </div>
+
+      <section className="card">
+        <header className="card-header">
+          <div>
+            <p className="eyebrow">Opinionated guardrails</p>
+            <h2>11/2025 best practices</h2>
+            <p className="muted">High-signal recommendations to keep the stack resilient, encrypted, and maintainable.</p>
+          </div>
+        </header>
+        <BestPractices />
+      </section>
+    </main>
   );
 }

--- a/webui/src/index.jsx
+++ b/webui/src/index.jsx
@@ -1,10 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import './style.css';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      staleTime: 10_000,
+    },
+  },
+});
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/webui/src/style.css
+++ b/webui/src/style.css
@@ -1,21 +1,272 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  background: #0c1116;
+  color: #e8ecf2;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: Arial, sans-serif;
-  background: #f7f8fa;
-  padding: 2rem;
+  margin: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(75, 156, 255, 0.12), transparent 25%),
+    radial-gradient(circle at 80% 10%, rgba(67, 213, 173, 0.1), transparent 20%), #0c1116;
+  min-height: 100vh;
 }
-.container {
-  max-width: 600px;
-  margin: auto;
-  text-align: center;
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 48px 24px 72px;
 }
-.buttons button {
-  margin: 0.5rem;
-  padding: 0.5rem 1rem;
-  font-size: 1rem;
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 24px;
+  margin-bottom: 24px;
 }
-pre {
-  text-align: left;
-  background: #eee;
-  padding: 1rem;
+
+.status-card {
+  background: linear-gradient(135deg, #1b2733, #16202b);
+  padding: 16px 20px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  min-width: 260px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+}
+
+.card {
+  background: #111923;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 18px;
+  margin-bottom: 16px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+}
+
+.card.inset {
+  background: #0e161f;
+  border-color: rgba(255, 255, 255, 0.06);
+}
+
+.card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+  margin: 16px 0;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.table {
+  width: 100%;
+  margin-top: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.table-row {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 8px;
+  padding: 10px 12px;
+}
+
+.table-head {
+  background: rgba(255, 255, 255, 0.05);
+  font-weight: 700;
+}
+
+.table-row:nth-child(odd):not(.table-head) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  color: #dfe7f5;
+}
+
+.pill.success {
+  background: rgba(76, 221, 166, 0.12);
+  color: #4cdda6;
+}
+
+.pill.warning {
+  background: rgba(255, 193, 64, 0.12);
+  color: #ffc140;
+}
+
+.pill.muted {
+  background: rgba(255, 255, 255, 0.06);
+  color: #9fb2c4;
+}
+
+.button-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+button {
+  border: 1px solid transparent;
+  background: linear-gradient(135deg, #3c86ff, #5fd6c0);
+  color: #0b1119;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+  box-shadow: 0 12px 32px rgba(63, 134, 255, 0.35);
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button.secondary {
+  background: #152032;
+  color: #d4e3ff;
+  border-color: rgba(255, 255, 255, 0.1);
+  box-shadow: none;
+}
+
+button.ghost {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.15);
+  color: #cfd9e8;
+  box-shadow: none;
+}
+
+button.danger {
+  background: #2b1418;
+  border-color: #ff6678;
+  color: #ffb3be;
+  box-shadow: 0 10px 24px rgba(255, 102, 120, 0.25);
+}
+
+.log-window {
+  background: #0b1119;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 12px;
+  color: #c7d5e6;
+  min-height: 120px;
+  max-height: 280px;
   overflow: auto;
+  white-space: pre-wrap;
+}
+
+.log-window.small {
+  max-height: 180px;
+  font-size: 13px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 12px;
+  color: #7ea2c9;
+  margin: 0 0 4px 0;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  color: #e9eef7;
+}
+
+p {
+  margin: 4px 0 10px;
+  color: #cbd8eb;
+}
+
+.muted {
+  color: #9fb2c4;
+}
+
+.error {
+  color: #ff7b91;
+}
+
+.raw-output summary {
+  cursor: pointer;
+  color: #9fb2c4;
+}
+
+.playbook-select {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+select {
+  background: #0f1722;
+  color: #d6e5ff;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.chip-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  background: rgba(255, 255, 255, 0.06);
+  color: #e8ecf2;
+  border-radius: 999px;
+  font-size: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.chip.success {
+  background: rgba(76, 221, 166, 0.12);
+  border-color: rgba(76, 221, 166, 0.4);
+  color: #4cdda6;
+}
+
+.chip.danger {
+  background: rgba(255, 102, 120, 0.1);
+  border-color: rgba(255, 102, 120, 0.4);
+  color: #ff9fb0;
+}
+
+.chip.muted {
+  color: #9fb2c4;
 }


### PR DESCRIPTION
## Summary
- replace the simple control panel with an agentic operator console that surfaces compose status, action logs, and prebuilt playbooks
- harden the API with validated compose actions, batch execution, and a curated 11/2025 best-practices feed
- refresh the UI styling and React Query data flows for modern, auto-refreshing status visibility

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b2ae75d1c832eaba72fbcd40ab09c)